### PR TITLE
Default directed graphs and MIT license

### DIFF
--- a/GFA2Network.py
+++ b/GFA2Network.py
@@ -14,7 +14,7 @@ RAM, so even a 2 M-node / 3 M-edge graph fits comfortably on a 16 GB laptop.
 ----------
 Quick usage
 ------------
-Build *both* outputs (default: undirected graph, CSR matrix):
+Build *both* outputs (default: directed graph, CSR matrix):
 
     python GFA2Network.py input.gfa \
         --graph \
@@ -29,7 +29,7 @@ Matrix-only run (lowest RAM):
 Directed graph only, verbose progress:
 
     python GFA2Network.py input.gfa \
-        --directed --graph --verbose
+        --graph --verbose
 
 -------------
 Positional argument
@@ -43,8 +43,8 @@ Optional arguments
 --matrix PATH        Write an adjacency matrix to *PATH*.
                      Extensions: *.npz* (sparse), *.csv* or *.npy* (dense).
 --matrix-format FMT  Sparse format for *.npz* (**csr**, csc, coo, dok). Default *csr*.
---directed           Treat the graph as directed.
---undirected         Treat the graph as undirected (**default**).
+--directed           Treat the graph as directed (**default**).
+--undirected         Treat the graph as undirected.
 --weight-tag TAG     Use numeric value of GFA tag *TAG* (e.g. *RC*) as edge
                      weight; otherwise every edge weight = 1.
 --verbose            Emit progress to *stderr* (every 500 k lines + tqdm bars).
@@ -283,10 +283,19 @@ def main(argv: Iterable[str] | None = None):
     )
     p.add_argument("gfa", help="Input *.gfa* file")
     g = p.add_mutually_exclusive_group()
-    g.add_argument("--directed", action="store_true", default=False,
-                   help="Treat graph as directed")
-    g.add_argument("--undirected", action="store_true", default=True,
-                   help="Treat graph as undirected (default)")
+    g.add_argument(
+        "--directed",
+        dest="directed",
+        action="store_true",
+        default=True,
+        help="Treat graph as directed (default)",
+    )
+    g.add_argument(
+        "--undirected",
+        dest="directed",
+        action="store_false",
+        help="Treat graph as undirected",
+    )
     p.add_argument("--graph", action="store_true",
                    help="Build a NetworkX object")
     p.add_argument("--matrix", metavar="PATH",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Steven Clipman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ processed on ordinary hardware.
 ## Quick start
 
 ```bash
-# build both outputs (undirected graph + CSR matrix)
+# build both outputs (directed graph + CSR matrix)
 python GFA2Network.py input.gfa --graph --matrix adj.npz
 
 # matrix only (lowest RAM) using COO format
 python GFA2Network.py input.gfa --matrix adj.npz --matrix-format coo
 
 # directed graph only with verbose progress
-python GFA2Network.py input.gfa --directed --graph --verbose
+python GFA2Network.py input.gfa --graph --verbose
 ```
 
 See `python GFA2Network.py -h` for all command line options.
@@ -49,5 +49,5 @@ specified path (`.npz`, `.npy` or `.csv`).
 
 ## License
 
-This repository does not currently contain an explicit license. Use at your own
-discretion.
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for
+details.


### PR DESCRIPTION
## Summary
- add MIT license
- default to directed graphs in the CLI
- update docstring and README examples

## Testing
- `python3 -m py_compile GFA2Network.py`
- `python3 GFA2Network.py -h` *(fails: ModuleNotFoundError: No module named 'networkx')*