### PR TITLE
Package gfa2network

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [GFA-2](https://github.com/GFA-spec/GFA-spec/blob/master/GFA2.md) pangenome
 variation graphs into handy Python objects.
 
-The script **GFA2Network.py** can build
+The command **gfa2network** can build
 
 - a `networkx.Graph` / `DiGraph`, and/or
 - a SciPy sparse adjacency matrix.
@@ -17,16 +17,16 @@ processed on ordinary hardware.
 
 ```bash
 # build both outputs (directed graph + CSR matrix)
-python GFA2Network.py input.gfa --graph --matrix adj.npz
+gfa2network input.gfa --graph --matrix adj.npz
 
 # matrix only (lowest RAM) using COO format
-python GFA2Network.py input.gfa --matrix adj.npz --matrix-format coo
+gfa2network input.gfa --matrix adj.npz --matrix-format coo
 
 # directed graph only with verbose progress
-python GFA2Network.py input.gfa --graph --verbose
+gfa2network input.gfa --graph --verbose
 ```
 
-See `python GFA2Network.py -h` for all command line options.
+See `gfa2network -h` for all command line options.
 
 ## Dependencies
 

--- a/gfa2network/__init__.py
+++ b/gfa2network/__init__.py
@@ -1,0 +1,3 @@
+from .cli import parse_gfa, convert_format
+
+__all__ = ["parse_gfa", "convert_format"]

--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-GFA2Network.py
-============================
+Command line interface for **gfa2network**.
+==========================================
 Load a (potentially huge) pangenome variation graph in **GFA-1** or **GFA-2**
 format and convert it into
 
@@ -16,19 +16,19 @@ Quick usage
 ------------
 Build *both* outputs (default: directed graph, CSR matrix):
 
-    python GFA2Network.py input.gfa \
+    gfa2network input.gfa \
         --graph \
         --matrix adj.npz
 
 Matrix-only run (lowest RAM):
 
-    python GFA2Network.py input.gfa \
+    gfa2network input.gfa \
         --matrix adj.npz \
         --matrix-format coo
 
 Directed graph only, verbose progress:
 
-    python GFA2Network.py input.gfa \
+    gfa2network input.gfa \
         --graph --verbose
 
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gfa2network"
+version = "0.1.0"
+description = "Convert GFA pangenome graphs to NetworkX graphs or SciPy matrices"
+authors = [{name = "", email = ""}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "networkx",
+    "numpy",
+]
+
+[project.optional-dependencies]
+scipy = ["scipy"]
+tqdm = ["tqdm"]
+
+[project.scripts]
+gfa2network = "gfa2network.cli:main"


### PR DESCRIPTION
## Summary
- move `GFA2Network.py` under a module as `gfa2network/cli.py`
- add a package `__init__`
- provide `pyproject.toml` with dependencies and console script entry point
- update README and docstrings to reference `gfa2network` command

## Testing
- `pip install networkx numpy` *(fails: no network access)*