### PR TITLE
Add --output option to convert command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ gfa2network convert input.gfa --matrix adj.npz --matrix-format coo
 # directed graph only with verbose progress
 gfa2network convert input.gfa --graph --verbose
 
-# build an igraph graph
-gfa2network convert input.gfa --backend igraph -o graph.pkl
+# build an igraph graph and save it
+gfa2network convert input.gfa --graph --backend igraph -o graph.pkl
 
 # stream from stdin and strip orientations (legacy behaviour)
 cat input.gfa | gfa2network convert - --graph --strip-orientation
@@ -80,6 +80,7 @@ See `gfa2network -h` for all command line options.
 | `--graph`          | Build a NetworkX object |
 | `--matrix PATH`    | Write adjacency matrix to PATH |
 | `--matrix-format`  | Sparse format for `.npz` (csr\|csc\|coo\|dok) |
+| `-o PATH, --output PATH` | Save graph pickle to PATH |
 | `--backend`        | Backend for graph building (`networkx`\|`igraph`) |
 | `--directed`       | Treat graph as directed (default) |
 | `--undirected`     | Treat graph as undirected |
@@ -138,9 +139,11 @@ weights with `--weight-tag TAG`.
 ## Output
 
 If `--graph` is provided, a NetworkX graph is exposed as `G` when running the
-script directly. With `--matrix PATH`, an adjacency matrix is written to the
-specified path (`.npz`, `.npy` or `.csv`).  Matrices are produced in COO format
-and can be converted to other sparse formats via the `convert_format` helper.
+script directly.  Use `-o PATH`/`--output PATH` to save the graph to disk
+(NetworkX `gpickle` or igraph pickle).  With `--matrix PATH`, an adjacency
+matrix is written to the specified path (`.npz`, `.npy` or `.csv`).  Matrices
+are produced in COO format and can be converted to other sparse formats via the
+`convert_format` helper.
 
 ## License
 

--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -62,6 +62,12 @@ def main(argv: list[str] | None = None) -> None:
     )
     p_conv.add_argument("--bidirected", action="store_true", help="Use bidirected representation")
     p_conv.add_argument("--verbose", action="store_true")
+    p_conv.add_argument(
+        "-o",
+        "--output",
+        metavar="PATH",
+        help="Write graph pickle to PATH",
+    )
 
     p_exp = sub.add_parser("export", help="Stream edges in simple formats")
     p_exp.add_argument("gfa")
@@ -124,6 +130,17 @@ def main(argv: list[str] | None = None) -> None:
             save_matrix(A, Path(args.matrix), verbose=args.verbose)
         if build_g:
             globals().update({"G": G})
+            if args.output:
+                if args.backend == "networkx":
+                    if hasattr(nx, "write_gpickle"):
+                        nx.write_gpickle(G, args.output)
+                    else:  # pragma: no cover - legacy NetworkX
+                        import pickle
+
+                        with open(args.output, "wb") as fh:
+                            pickle.dump(G, fh)
+                else:
+                    G.write_pickle(args.output)
     elif args.cmd == "export":
         parser_format = args.format
         out_path = Path(args.output) if args.output != "-" else None

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -1,0 +1,65 @@
+import subprocess
+import sys
+from pathlib import Path
+import networkx as nx
+import pytest
+
+SAMPLE_GFA = b"""S\ts1\t4\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\n"""
+
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "sample.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_convert_save_networkx(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "g.pkl"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gfa2network",
+            "convert",
+            str(gfa),
+            "--graph",
+            "-o",
+            str(out),
+        ],
+        check=True,
+    )
+    if hasattr(nx, "read_gpickle"):
+        G = nx.read_gpickle(out)
+    else:
+        import pickle
+
+        with open(out, "rb") as fh:
+            G = pickle.load(fh)
+    assert G.number_of_nodes() == 2
+    assert G.number_of_edges() == 1
+
+
+def test_convert_save_igraph(tmp_path: Path):
+    ig = pytest.importorskip("igraph")
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "g.pkl"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gfa2network",
+            "convert",
+            str(gfa),
+            "--graph",
+            "--backend",
+            "igraph",
+            "-o",
+            str(out),
+        ],
+        check=True,
+    )
+    G = ig.Graph.Read_Pickle(str(out))
+    assert G.vcount() == 2
+    assert G.ecount() == 1
+


### PR DESCRIPTION
## Summary
- add `-o/--output` argument to the `convert` command
- save the built graph when `--output` is provided
- document the new option in README and fix quickstart example
- test saving graphs with both networkx and igraph backends

## Testing
- `python -m pytest -q`