### PR TITLE
Add gzip input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ processed on ordinary hardware.
 - Helper utilities to convert or save matrices
 - Bidirected graph representation via `--bidirected`
 - Export edges to various formats with the `export` subcommand
+- Transparent support for gzip-compressed input files (`*.gfa.gz`)
 
 The adjacency matrix can be written in several SciPy sparse representations:
 
@@ -62,7 +63,7 @@ python -m pytest
 ## Quick start
 
 The examples below illustrate typical use cases.  Replace `input.gfa` with your
-own data set.
+own data set.  Files may also be gzip-compressed (`input.gfa.gz`).
 
 ```bash
 # Build both representations (directed NetworkX graph and CSR matrix)
@@ -122,6 +123,8 @@ from gfa2network import parse_gfa
 
 # Build a NetworkX graph
 G = parse_gfa("input.gfa", build_graph=True, build_matrix=False)
+# Compressed input works as well
+Gz = parse_gfa("input.gfa.gz", build_graph=True, build_matrix=False)
 ```
 
 Pass `directed=False` for an undirected graph or specify a `weight_tag`

--- a/gfa2network/parser.py
+++ b/gfa2network/parser.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, BinaryIO, Iterator, Iterable, Tuple
 import sys
 import warnings
+import gzip
 
 
 @dataclass
@@ -92,7 +93,10 @@ class GFAParser:
             if path == "-":
                 fh = sys.stdin.buffer
             else:
-                fh = open(path, "rb", buffering=1 << 20)
+                if str(path).endswith(".gz"):
+                    fh = gzip.open(path, "rb")
+                else:
+                    fh = open(path, "rb", buffering=1 << 20)
             close = path != "-"
         try:
             for line in fh:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import subprocess
 import sys
 import warnings
+import gzip
 
 from gfa2network import parse_gfa
 from gfa2network.parser import GFAParser, PathRecord
@@ -91,3 +92,12 @@ def test_unknown_record_warning(tmp_path: Path):
     with warnings.catch_warnings(record=True) as w:
         list(GFAParser(gfa))
     assert len(w) == 1
+
+
+def test_gzip_input(tmp_path: Path):
+    gz = tmp_path / "test.gfa.gz"
+    gz.write_bytes(gzip.compress(SAMPLE_GFA))
+    recs = list(GFAParser(gz))
+    assert len([r for r in recs if isinstance(r, PathRecord)]) == 1
+    G = parse_gfa(gz, build_graph=True, build_matrix=False)
+    assert G.number_of_nodes() == 2


### PR DESCRIPTION
## Summary
- support gzip compressed input files in `GFAParser`
- document gzip feature in README
- test parsing of `.gfa.gz`

## Testing
- `PYTHONPATH=$PWD pytest -q`