### PR TITLE
Add lint tooling and cleanup

### DIFF
--- a/gfa2network/analysis.py
+++ b/gfa2network/analysis.py
@@ -4,6 +4,7 @@ import networkx as nx
 
 try:
     import pandas as pd  # type: ignore
+
     _HAS_PANDAS = True
 except Exception:  # pragma: no cover - optional dependency
     pd = None  # type: ignore

--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -66,7 +66,9 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Strip +/- from IDs (v0.1 behaviour)",
     )
-    p_conv.add_argument("--bidirected", action="store_true", help="Use bidirected representation")
+    p_conv.add_argument(
+        "--bidirected", action="store_true", help="Use bidirected representation"
+    )
     p_conv.add_argument("--verbose", action="store_true")
     p_conv.add_argument(
         "-o",
@@ -77,7 +79,11 @@ def main(argv: list[str] | None = None) -> None:
 
     p_exp = sub.add_parser("export", help="Stream edges in simple formats")
     p_exp.add_argument("gfa")
-    p_exp.add_argument("--format", default="edge-list", choices=["edge-list", "graphml", "gexf", "json"])
+    p_exp.add_argument(
+        "--format",
+        default="edge-list",
+        choices=["edge-list", "graphml", "gexf", "json"],
+    )
     p_exp.add_argument("--bidirected", action="store_true")
     p_exp.add_argument("--output", help="Output path", default="-")
 
@@ -99,7 +105,9 @@ def main(argv: list[str] | None = None) -> None:
 
     p_dm = sub.add_parser("distance-matrix", help="Pairwise distances between paths")
     p_dm.add_argument("gfa", help="Input *.gfa* file")
-    p_dm.add_argument("-o", "--output", required=True, help="Write matrix to PATH (.csv|.npy|.npz)")
+    p_dm.add_argument(
+        "-o", "--output", required=True, help="Write matrix to PATH (.csv|.npy|.npz)"
+    )
     p_dm.add_argument("--method", choices=["min", "mean"], default="min")
 
     args = parser.parse_args(argv)
@@ -219,7 +227,9 @@ def main(argv: list[str] | None = None) -> None:
                 nodes_b = paths[name_b.encode()]
             except KeyError as exc:
                 raise SystemExit(f"unknown path: {exc.args[0].decode()}") from exc
-            G = parse_gfa(args.gfa, build_graph=True, build_matrix=False, directed=args.directed)
+            G = parse_gfa(
+                args.gfa, build_graph=True, build_matrix=False, directed=args.directed
+            )
             dist = genome_distance(G, nodes_a, nodes_b)
         print(dist)
     elif args.cmd == "distance-matrix":

--- a/gfa2network/igraph_builder.py
+++ b/gfa2network/igraph_builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 try:
     import igraph as ig
+
     _HAS_IGRAPH = True
 except Exception:  # pragma: no cover - optional dependency
     ig = None  # type: ignore
@@ -9,6 +10,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 try:
     import scipy.sparse as sp
+
     _HAS_SCIPY = True
 except Exception:  # pragma: no cover - optional dependency
     sp = None  # type: ignore
@@ -99,6 +101,7 @@ class IGraphBuilder:
 
 
 # ----------------------------------------------------------------------
+
 
 def parse_gfa_igraph(
     path: str | bytes,

--- a/gfa2network/parser.py
+++ b/gfa2network/parser.py
@@ -82,7 +82,9 @@ class GFAParser:
             self.file = source
         self._warned_unknown = False
 
-    def __iter__(self) -> Iterator[
+    def __iter__(
+        self,
+    ) -> Iterator[
         Segment | Link | EdgeRecord | ContainmentRecord | PathRecord | WalkRecord
     ]:
         if self.file is not None:
@@ -102,7 +104,14 @@ class GFAParser:
             for line in fh:
                 if not line:
                     continue
-                if line[0] not in (ord("S"), ord("L"), ord("P"), ord("E"), ord("C"), ord("O")):
+                if line[0] not in (
+                    ord("S"),
+                    ord("L"),
+                    ord("P"),
+                    ord("E"),
+                    ord("C"),
+                    ord("O"),
+                ):
                     if line[0] not in (ord("H"), ord("F")) and not self._warned_unknown:
                         warnings.warn(
                             f"Skipping unsupported record: {line[:1].decode()}",
@@ -125,14 +134,22 @@ class GFAParser:
                                 fourth = fields[3]
                                 # Heuristically detect if field 4 is a tag
                                 parts = fourth.split(b":", 2)
-                                if len(parts) == 3 and len(parts[0]) == 2 and len(parts[1]) == 1:
+                                if (
+                                    len(parts) == 3
+                                    and len(parts[0]) == 2
+                                    and len(parts[1]) == 1
+                                ):
                                     tag_start = 3
                                 else:
                                     seq = fourth
                                     tag_start = 4
                         except ValueError:
                             seq = third
-                    tags = self._parse_tags(fields[tag_start:]) if len(fields) > tag_start else None
+                    tags = (
+                        self._parse_tags(fields[tag_start:])
+                        if len(fields) > tag_start
+                        else None
+                    )
                     yield Segment(fields[1], length, seq, tags)
                 elif rec_type == b"L":
                     yield self._parse_link(fields)
@@ -154,24 +171,24 @@ class GFAParser:
         tags: dict[str, Any] = {}
         for f in fields:
             try:
-                tag, typ, value = f.decode().split(':', 2)
+                tag, typ, value = f.decode().split(":", 2)
             except ValueError:
                 continue
-            if typ == 'i':
+            if typ == "i":
                 try:
                     tags[tag] = int(value)
                 except ValueError:
                     pass
-            elif typ == 'f':
+            elif typ == "f":
                 try:
                     tags[tag] = float(value)
                 except ValueError:
                     pass
-            elif typ == 'B':
+            elif typ == "B":
                 try:
-                    tags[tag] = [int(x) for x in value.split(',') if x]
+                    tags[tag] = [int(x) for x in value.split(",") if x]
                 except ValueError:
-                    tags[tag] = value.split(',')
+                    tags[tag] = value.split(",")
             else:
                 tags[tag] = value
         return tags or None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ tqdm = ["tqdm"]
 
 [project.scripts]
 gfa2network = "gfa2network.cli:main"
+
+[tool.black]
+line-length = 88

--- a/scripts/lint_check.sh
+++ b/scripts/lint_check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+black --check gfa2network tests
+flake8 gfa2network tests

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -62,4 +62,3 @@ def test_convert_save_igraph(tmp_path: Path):
     G = ig.Graph.Read_Pickle(str(out))
     assert G.vcount() == 2
     assert G.ecount() == 1
-

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -14,16 +14,19 @@ SAMPLE_SEQ_GFA = b"""S\ts1\tACGT\nS\ts2\tTTTT\nL\ts1\t+\ts2\t+\t0M\n"""
 
 SAMPLE_PATH_GFA = b"""S\ts1\t*\nS\ts2\t*\nS\ts3\t*\nL\ts1\t+\ts2\t+\t0M\nL\ts2\t+\ts3\t+\t0M\nP\tp1\ts1+,s2+\t*\nP\tp2\ts3+,s2+\t*\n"""
 
+
 def write_gfa(tmp_path: Path, content: bytes, name: str) -> Path:
     gfa = tmp_path / name
     gfa.write_bytes(content)
     return gfa
+
 
 def test_sequence_distance(tmp_path: Path):
     gfa = write_gfa(tmp_path, SAMPLE_SEQ_GFA, "seq.gfa")
     G = parse_gfa(gfa, build_graph=True, build_matrix=False, store_seq=True)
     dist = sequence_distance(G, b"ACGT", b"TTTT")
     assert dist == 1
+
 
 def test_genome_distance(tmp_path: Path):
     gfa = write_gfa(tmp_path, SAMPLE_PATH_GFA, "paths.gfa")
@@ -41,6 +44,7 @@ def test_genome_distance_matrix(tmp_path: Path):
     arr = M.values if hasattr(M, "values") else M
     assert arr.shape == (2, 2)
     assert np.allclose(arr, [[0, 0], [0, 0]])
+
 
 def test_cli_distance_seq(tmp_path: Path):
     gfa = write_gfa(tmp_path, SAMPLE_SEQ_GFA, "cli_seq.gfa")
@@ -60,6 +64,7 @@ def test_cli_distance_seq(tmp_path: Path):
         check=True,
     )
     assert result.stdout.strip() == "1"
+
 
 def test_cli_distance_path(tmp_path: Path):
     gfa = write_gfa(tmp_path, SAMPLE_PATH_GFA, "cli_path.gfa")


### PR DESCRIPTION
## Summary
- format python files with `black`
- add flake8 and black lint check script
- configure black line length

## Testing
- `black --check gfa2network tests`
- `bash scripts/lint_check.sh` *(fails: flake8 not installed)*
- `PYTHONPATH=. pytest -q`