### PR TITLE
Expand adjacency matrix options

### DIFF
--- a/gfa2network/builders.py
+++ b/gfa2network/builders.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import networkx as nx
+import numpy as np
 import sys
 
 from .parser import (
@@ -36,6 +37,8 @@ def parse_gfa(
     verbose: bool = False,
     bidirected: bool = False,
     backend: str = "networkx",
+    dtype: str | object = "float64",
+    asymmetric: bool = False,
 ):
     """Stream-parse *path* and return requested artefacts.
 
@@ -152,7 +155,10 @@ def parse_gfa(
     out_mat = None
     if build_matrix:
         n = len(node2idx)
-        out_mat = sp.coo_matrix((data, (rows, cols)), shape=(n, n), dtype=float)
+        dt = np.dtype(dtype)
+        out_mat = sp.coo_matrix((data, (rows, cols)), shape=(n, n), dtype=dt)
+        if not asymmetric:
+            out_mat = out_mat.maximum(out_mat.T)
 
     if build_graph and build_matrix:
         return out_graph, out_mat

--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -59,6 +59,17 @@ def main(argv: list[str] | None = None) -> None:
         default="csr",
         help="Sparse format for .npz (csr|csc|coo|dok)",
     )
+    p_conv.add_argument(
+        "--dtype",
+        choices=["bool", "int8", "int32", "float32", "float64"],
+        default="float64",
+        help="Data type for adjacency matrix",
+    )
+    p_conv.add_argument(
+        "--asymmetric",
+        action="store_true",
+        help="Do not mirror upper triangle",
+    )
     p_conv.add_argument("--weight-tag")
     p_conv.add_argument("--store-seq", action="store_true")
     p_conv.add_argument(
@@ -136,6 +147,8 @@ def main(argv: list[str] | None = None) -> None:
             verbose=args.verbose,
             bidirected=args.bidirected,
             backend=args.backend,
+            dtype=args.dtype,
+            asymmetric=args.asymmetric,
         )
         if build_g and build_mat:
             G, A = result  # type: ignore[misc]

--- a/tests/test_matrix_asym.py
+++ b/tests/test_matrix_asym.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import subprocess
+import sys
+import scipy.sparse as sp
+
+SAMPLE_GFA = b"""S\ts1\t4\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\n"""
+
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "sample.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_matrix_asymmetric(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "adj.npz"
+    subprocess.run([
+        sys.executable,
+        "-m",
+        "gfa2network",
+        "convert",
+        str(gfa),
+        "--matrix",
+        str(out),
+        "--asymmetric",
+    ], check=True)
+    A = sp.load_npz(out)
+    arr = A.toarray()
+    assert not (arr == arr.T).all()

--- a/tests/test_matrix_dtype.py
+++ b/tests/test_matrix_dtype.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import subprocess
+import sys
+import scipy.sparse as sp
+
+SAMPLE_GFA = b"""S\ts1\t4\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\n"""
+
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "sample.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_matrix_dtype(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "adj.npz"
+    subprocess.run([
+        sys.executable,
+        "-m",
+        "gfa2network",
+        "convert",
+        str(gfa),
+        "--matrix",
+        str(out),
+        "--dtype",
+        "bool",
+    ], check=True)
+    A = sp.load_npz(out)
+    assert A.dtype == bool


### PR DESCRIPTION
## Summary
- add `dtype` and `asymmetric` flags to the convert CLI
- support dtype and asymmetry when building matrices
- tests for dtype handling and asymmetric matrix output

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `python -m gfa2network convert tests/data/DRB1-3123_unsorted.gfa --matrix adj.npz --dtype int8 --asymmetric`