### PR TITLE
Add timing output and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install .[igraph] pytest flake8 black pytest-cov
+      - name: Lint
+        run: scripts/lint_check.sh
+      - name: Tests
+        run: pytest --cov=gfa2network --cov-report=xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
     style="margin-right:10px;"/>
 </p>
 
-# GFA2Network: Memory-efficent GFA→Graph Converter
+[![CI](https://github.com/sclipman/gfa2network/actions/workflows/ci.yml/badge.svg)](https://github.com/sclipman/gfa2network/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/gfa2network)](https://pypi.org/project/gfa2network)
+[![codecov](https://codecov.io/gh/sclipman/gfa2network/branch/main/graph/badge.svg)](https://codecov.io/gh/sclipman/gfa2network)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+# GFA2Network: Memory-efficient GFA→Graph Converter
 
 **GFA2Network** is a small Python library that converts
 [GFA-1](https://github.com/GFA-spec/GFA-spec) and

--- a/tests/test_matrix_asym.py
+++ b/tests/test_matrix_asym.py
@@ -15,16 +15,19 @@ def write_gfa(tmp_path: Path) -> Path:
 def test_matrix_asymmetric(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     out = tmp_path / "adj.npz"
-    subprocess.run([
-        sys.executable,
-        "-m",
-        "gfa2network",
-        "convert",
-        str(gfa),
-        "--matrix",
-        str(out),
-        "--asymmetric",
-    ], check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gfa2network",
+            "convert",
+            str(gfa),
+            "--matrix",
+            str(out),
+            "--asymmetric",
+        ],
+        check=True,
+    )
     A = sp.load_npz(out)
     arr = A.toarray()
     assert not (arr == arr.T).all()

--- a/tests/test_matrix_dtype.py
+++ b/tests/test_matrix_dtype.py
@@ -15,16 +15,19 @@ def write_gfa(tmp_path: Path) -> Path:
 def test_matrix_dtype(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     out = tmp_path / "adj.npz"
-    subprocess.run([
-        sys.executable,
-        "-m",
-        "gfa2network",
-        "convert",
-        str(gfa),
-        "--matrix",
-        str(out),
-        "--dtype",
-        "bool",
-    ], check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gfa2network",
+            "convert",
+            str(gfa),
+            "--matrix",
+            str(out),
+            "--dtype",
+            "bool",
+        ],
+        check=True,
+    )
     A = sp.load_npz(out)
     assert A.dtype == bool

--- a/tests/test_verbose_timing.py
+++ b/tests/test_verbose_timing.py
@@ -1,0 +1,43 @@
+import sys
+import subprocess
+import re
+import sys
+from pathlib import Path
+import pytest
+
+SAMPLE_GFA = b"""S\ts1\t4\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\n"""
+
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "sample.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="timing output differs on Windows"
+)
+def test_verbose_timing(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "adj.npz"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gfa2network",
+            "convert",
+            str(gfa),
+            "--matrix",
+            str(out),
+            "--verbose",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pattern = r"Parsed in \d+\.\d{3} s"
+    assert re.search(pattern, result.stdout)
+    pattern = r"Built (graph|matrix|graph and matrix) in \d+\.\d{3} s"
+    assert re.search(pattern, result.stdout)
+    pattern = r"Exported in \d+\.\d{3} s"
+    assert re.search(pattern, result.stdout)


### PR DESCRIPTION
## Summary
- show CI, PyPI, codecov and license badges
- add GitHub Actions workflow for lint/test/coverage
- emit verbose timing for `convert`
- test timing output

## Testing
- `scripts/lint_check.sh`
- `PYTHONPATH=. pytest -q`