### PR TITLE
Fix actions/upload-artifact warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Tests
         run: pytest --cov=gfa2network --cov-report=xml
       - name: Upload coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to v4 in CI workflow

## Testing
- `pip install -e .[igraph]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gfa2network')*