### PR TITLE
Fix packaging by specifying gfa2network package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,8 @@ gfa2network = "gfa2network.cli:main"
 
 [tool.black]
 line-length = 88
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["gfa2network*"]
+exclude = ["assets"]


### PR DESCRIPTION
## Summary
- fix setuptools package discovery so `assets` doesn't interfere with building

## Testing
- `scripts/lint_check.sh`
- `pytest` (with `PYTHONPATH` set because pip install fails offline)
