### PR TITLE
Bidirected undirected edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See `gfa2network -h` for all command line options.
 | `--store-seq`      | Keep sequences from `S` records on nodes |
 | `--strip-orientation` | Remove `+/-` from IDs (legacy) |
 | `--bidirected`     | Use bidirected node representation |
+| `--keep-directed-bidir` | Keep directed bidirected edges |
 | `--verbose`        | Emit progress information |
 
 `--store-seq` may drastically increase memory usage. The parser will warn when the

--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -80,6 +80,11 @@ def main(argv: list[str] | None = None) -> None:
     p_conv.add_argument(
         "--bidirected", action="store_true", help="Use bidirected representation"
     )
+    p_conv.add_argument(
+        "--keep-directed-bidir",
+        action="store_true",
+        help="Keep original directed bidirected behaviour",
+    )
     p_conv.add_argument("--verbose", action="store_true")
     p_conv.add_argument(
         "-o",
@@ -96,6 +101,11 @@ def main(argv: list[str] | None = None) -> None:
         choices=["edge-list", "graphml", "gexf", "json"],
     )
     p_exp.add_argument("--bidirected", action="store_true")
+    p_exp.add_argument(
+        "--keep-directed-bidir",
+        action="store_true",
+        help="Keep original directed bidirected behaviour",
+    )
     p_exp.add_argument("--output", help="Output path", default="-")
 
     p_stats = sub.add_parser("stats", help="Print basic graph statistics")
@@ -146,6 +156,7 @@ def main(argv: list[str] | None = None) -> None:
             strip_orientation=args.strip_orientation,
             verbose=args.verbose,
             bidirected=args.bidirected,
+            keep_directed_bidir=args.keep_directed_bidir,
             backend=args.backend,
             dtype=args.dtype,
             asymmetric=args.asymmetric,
@@ -197,6 +208,7 @@ def main(argv: list[str] | None = None) -> None:
                 directed=True,
                 strip_orientation=False,
                 bidirected=args.bidirected,
+                keep_directed_bidir=args.keep_directed_bidir,
             )
             if parser_format == "graphml":
                 nx.write_graphml(G, args.output)

--- a/tests/test_bidirected.py
+++ b/tests/test_bidirected.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import networkx as nx
+from gfa2network import parse_gfa
+
+SAMPLE_GFA = b"""S\ts1\t4\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\n"""
+
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "sample.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_bidirected_edges_and_distance(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(gfa, build_graph=True, build_matrix=False, bidirected=True)
+    assert not G.is_directed()
+    assert G.has_edge(b"s1:+", b"s2:-")
+    assert G.has_edge(b"s2:+", b"s1:-")
+    d1 = nx.shortest_path_length(G, b"s1:+", b"s2:-")
+    d2 = nx.shortest_path_length(G, b"s2:+", b"s1:-")
+    assert d1 == d2 == 1


### PR DESCRIPTION
## Summary
- allow undirected graphs with `--bidirected`
- mirror reverse-complement edges when building graphs
- add CLI flag `--keep-directed-bidir`
- skip symmetric mirroring on undirected matrices
- document new option and test bidirected connectivity

## Testing
- `PYTHONPATH=. pytest -q`