### PR TITLE
Decode bytes IDs to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.7.0
+- Node identifiers are now decoded to strings when building NetworkX graphs.
+- Added `--raw-bytes-id` CLI flag for legacy byte behaviour.
+- GraphML and GEXF exports use plain string IDs.
+
 ## v0.6.0
 - Added optional pandas support in `analysis` for DataFrame results
 - Introduced `genome_distance_matrix` helper

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See `gfa2network -h` for all command line options.
 | `--store-seq`      | Keep sequences from `S` records on nodes |
 | `--strip-orientation` | Remove `+/-` from IDs (legacy) |
 | `--bidirected`     | Use bidirected node representation |
+| `--raw-bytes-id`   | Use legacy byte strings for node IDs |
 | `--keep-directed-bidir` | Keep directed bidirected edges |
 | `--verbose`        | Emit progress information |
 
@@ -193,7 +194,7 @@ dist = sequence_distance(G_seq, "ACGT", "TTTT")
 
 # Load path definitions and compare two genomes
 paths = load_paths("input.gfa")
-dist2 = genome_distance(G, paths[b"p1"], paths[b"p2"])
+dist2 = genome_distance(G, paths["p1"], paths["p2"])
 
 # Pairwise distances between all paths
 mat = genome_distance_matrix("input.gfa")
@@ -225,6 +226,7 @@ matrix into CSR/CSC/DOK formats.
 | ``strip_orientation`` | Remove ``+/-`` from segment IDs |
 | ``verbose`` | Print progress messages |
 | ``bidirected`` | Append orientation to node IDs |
+| ``raw_bytes_id`` | Use byte strings for node IDs |
 
 ## Implementation Notes
 

--- a/tests/test_bidirected.py
+++ b/tests/test_bidirected.py
@@ -15,8 +15,8 @@ def test_bidirected_edges_and_distance(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     G = parse_gfa(gfa, build_graph=True, build_matrix=False, bidirected=True)
     assert not G.is_directed()
-    assert G.has_edge(b"s1:+", b"s2:-")
-    assert G.has_edge(b"s2:+", b"s1:-")
-    d1 = nx.shortest_path_length(G, b"s1:+", b"s2:-")
-    d2 = nx.shortest_path_length(G, b"s2:+", b"s1:-")
+    assert G.has_edge("s1:+", "s2:-")
+    assert G.has_edge("s2:+", "s1:-")
+    d1 = nx.shortest_path_length(G, "s1:+", "s2:-")
+    d2 = nx.shortest_path_length(G, "s2:+", "s1:-")
     assert d1 == d2 == 1

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -32,7 +32,7 @@ def test_genome_distance(tmp_path: Path):
     gfa = write_gfa(tmp_path, SAMPLE_PATH_GFA, "paths.gfa")
     paths = load_paths(str(gfa))
     G = parse_gfa(gfa, build_graph=True, build_matrix=False)
-    d = genome_distance(G, paths[b"p1"], paths[b"p2"], method="min")
+    d = genome_distance(G, paths["p1"], paths["p2"], method="min")
     assert d == 0
 
 

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -1,0 +1,67 @@
+import subprocess
+import sys
+from pathlib import Path
+import networkx as nx
+
+SAMPLE_GFA = b"""S\ts1\t4\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\n"""
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "sample.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_export_graphml(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "g.graphml"
+    subprocess.run([
+        sys.executable,
+        "-m",
+        "gfa2network",
+        "export",
+        str(gfa),
+        "--format",
+        "graphml",
+        "--output",
+        str(out),
+    ], check=True)
+    G = nx.read_graphml(out)
+    assert sorted(G.nodes()) == ["s1", "s2"]
+
+
+def test_export_gexf(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "g.gexf"
+    subprocess.run([
+        sys.executable,
+        "-m",
+        "gfa2network",
+        "export",
+        str(gfa),
+        "--format",
+        "gexf",
+        "--output",
+        str(out),
+    ], check=True)
+    G = nx.read_gexf(out)
+    assert sorted(G.nodes()) == ["s1", "s2"]
+
+
+def test_export_raw_bytes(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    out = tmp_path / "g.graphml"
+    subprocess.run([
+        sys.executable,
+        "-m",
+        "gfa2network",
+        "--raw-bytes-id",
+        "export",
+        str(gfa),
+        "--format",
+        "graphml",
+        "--output",
+        str(out),
+    ], check=True)
+    G = nx.read_graphml(out)
+    assert sorted(G.nodes()) == ["b's1'", "b's2'"]
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,15 +20,15 @@ def write_gfa(tmp_path: Path) -> Path:
 def test_orientation_attributes(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     G = parse_gfa(gfa, build_graph=True, build_matrix=False)
-    assert G.edges[(b"s1", b"s2")]["orientation_from"] == "+"
-    assert G.edges[(b"s1", b"s2")]["orientation_to"] == "-"
+    assert G.edges[("s1", "s2")]["orientation_from"] == "+"
+    assert G.edges[("s1", "s2")]["orientation_to"] == "-"
 
 
 def test_strip_orientation(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     G = parse_gfa(gfa, build_graph=True, build_matrix=False, strip_orientation=True)
-    assert b"s1" in G.nodes
-    assert "orientation_from" not in G.edges[(b"s1", b"s2")]
+    assert "s1" in G.nodes
+    assert "orientation_from" not in G.edges[("s1", "s2")]
 
 
 def test_path_record(tmp_path: Path):
@@ -75,7 +75,7 @@ def test_tag_parsing(tmp_path: Path):
 def test_bidirected(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     G = parse_gfa(gfa, build_graph=True, build_matrix=False, bidirected=True)
-    assert (b"s1:+", b"s2:-") in G.edges
+    assert ("s1:+", "s2:-") in G.edges
 
 
 def test_segment_length(tmp_path: Path):
@@ -101,3 +101,9 @@ def test_gzip_input(tmp_path: Path):
     assert len([r for r in recs if isinstance(r, PathRecord)]) == 1
     G = parse_gfa(gz, build_graph=True, build_matrix=False)
     assert G.number_of_nodes() == 2
+
+
+def test_raw_bytes_flag(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(gfa, build_graph=True, build_matrix=False, raw_bytes_id=True)
+    assert b"s1" in G.nodes

--- a/tests/test_store_seq.py
+++ b/tests/test_store_seq.py
@@ -13,10 +13,10 @@ def write_gfa(tmp_path: Path) -> Path:
 def test_store_seq_on(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     G = parse_gfa(gfa, build_graph=True, build_matrix=False, store_seq=True)
-    assert G.nodes[b"s1"]["sequence"] == b"ACGT"
+    assert G.nodes["s1"]["sequence"] == b"ACGT"
 
 
 def test_store_seq_off(tmp_path: Path):
     gfa = write_gfa(tmp_path)
     G = parse_gfa(gfa, build_graph=True, build_matrix=False, store_seq=False)
-    assert "sequence" not in G.nodes[b"s1"]
+    assert "sequence" not in G.nodes["s1"]


### PR DESCRIPTION
## Summary
- decode node identifiers to strings by default
- add `--raw-bytes-id` flag to keep legacy behaviour
- support decoded IDs in analysis helpers
- update CLI and README docs
- add regression tests for GraphML/GEXF export
- update CHANGELOG

## Testing
- `python -m pytest -q`