### PR TITLE
Add optional tag storage with warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.8.0
+- Added `--store-tags` option to keep tag dictionaries and segment lengths on
+  nodes and edges. A `RuntimeWarning` is issued when stored tags exceed
+  100&nbsp;MB.
+
 ## v0.7.0
 - Node identifiers are now decoded to strings when building NetworkX graphs.
 - Added `--raw-bytes-id` CLI flag for legacy byte behaviour.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ See `gfa2network -h` for all command line options.
 | `--undirected`     | Treat graph as undirected |
 | `--weight-tag TAG` | Use numeric value of GFA tag `TAG` as edge weight |
 | `--store-seq`      | Keep sequences from `S` records on nodes |
+| `--store-tags`     | Attach tag dictionaries and lengths |
 | `--strip-orientation` | Remove `+/-` from IDs (legacy) |
 | `--bidirected`     | Use bidirected node representation |
 | `--raw-bytes-id`   | Use legacy byte strings for node IDs |
@@ -166,7 +167,9 @@ See `gfa2network -h` for all command line options.
 
 `--store-seq` may drastically increase memory usage. The parser will warn when the
 stored sequences exceed half of the available RAM. The flag is ignored when only
-`--matrix` is requested.
+`--matrix` is requested. The `--store-tags` option adds tag dictionaries and
+segment lengths to the graph. A `RuntimeWarning` is emitted if more than
+100&nbsp;MB are used for stored tags.
 
 ## Using in Python
 
@@ -182,6 +185,8 @@ G = parse_gfa("input.gfa", build_graph=True, build_matrix=False)
 Gz = parse_gfa("input.gfa.gz", build_graph=True, build_matrix=False)
 # Store sequences on nodes
 G_seq = parse_gfa("input.gfa", build_graph=True, build_matrix=False, store_seq=True)
+# Store tags and segment lengths
+G_tags = parse_gfa("input.gfa", build_graph=True, build_matrix=False, store_tags=True)
 ```
 
 Additional helpers are provided in ``gfa2network.analysis``:
@@ -223,6 +228,7 @@ matrix into CSR/CSC/DOK formats.
 | ``directed`` | Treat graph as directed (default ``True``) |
 | ``weight_tag`` | Numeric GFA tag to use as edge weight |
 | ``store_seq`` | Attach sequences to nodes |
+| ``store_tags`` | Attach tag dictionaries and lengths |
 | ``strip_orientation`` | Remove ``+/-`` from segment IDs |
 | ``verbose`` | Print progress messages |
 | ``bidirected`` | Append orientation to node IDs |

--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -77,6 +77,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     p_conv.add_argument("--weight-tag")
     p_conv.add_argument("--store-seq", action="store_true")
+    p_conv.add_argument("--store-tags", action="store_true")
     p_conv.add_argument(
         "--strip-orientation",
         action="store_true",
@@ -158,6 +159,7 @@ def main(argv: list[str] | None = None) -> None:
             directed=args.directed,
             weight_tag=args.weight_tag,
             store_seq=args.store_seq,
+            store_tags=args.store_tags,
             strip_orientation=args.strip_orientation,
             verbose=args.verbose,
             bidirected=args.bidirected,

--- a/gfa2network/igraph_builder.py
+++ b/gfa2network/igraph_builder.py
@@ -28,6 +28,7 @@ class IGraphBuilder:
         directed: bool = True,
         weight_tag: str | None = None,
         store_seq: bool = False,
+        store_tags: bool = False,
         strip_orientation: bool = False,
         bidirected: bool = False,
         keep_directed_bidir: bool = False,
@@ -38,6 +39,7 @@ class IGraphBuilder:
             self.directed = directed
         self.weight_tag = weight_tag
         self.store_seq = store_seq
+        self.store_tags = store_tags
         self.strip_orientation = strip_orientation
         self.bidirected = bidirected
         self.keep_directed_bidir = keep_directed_bidir
@@ -53,11 +55,11 @@ class IGraphBuilder:
             idx = self.graph.vcount() - 1  # type: ignore[union-attr]
             self._node_index[node] = idx
             if seg is not None:
-                if seg.length is not None:
+                if self.store_tags and seg.length is not None:
                     self.graph.vs[idx]["length"] = seg.length  # type: ignore[union-attr]
                 if self.store_seq and seg.sequence is not None:
                     self.graph.vs[idx]["sequence"] = seg.sequence  # type: ignore[union-attr]
-                if seg.tags:
+                if self.store_tags and seg.tags:
                     self.graph.vs[idx]["tags"] = seg.tags  # type: ignore[union-attr]
         return idx
 
@@ -86,7 +88,7 @@ class IGraphBuilder:
         if not self.strip_orientation and not self.bidirected:
             attrs["orientation_from"] = rec.orientation_from
             attrs["orientation_to"] = rec.orientation_to
-        if rec.tags is not None:
+        if self.store_tags and rec.tags is not None:
             attrs["tags"] = rec.tags
         w = None
         if self.weight_tag and rec.tags and self.weight_tag in rec.tags:
@@ -124,6 +126,7 @@ def parse_gfa_igraph(
     directed: bool = True,
     weight_tag: str | None = None,
     store_seq: bool = False,
+    store_tags: bool = False,
     strip_orientation: bool = False,
     verbose: bool = False,
     bidirected: bool = False,
@@ -139,6 +142,7 @@ def parse_gfa_igraph(
         directed=directed,
         weight_tag=weight_tag,
         store_seq=store_seq,
+        store_tags=store_tags,
         strip_orientation=strip_orientation,
         bidirected=bidirected,
         keep_directed_bidir=keep_directed_bidir,

--- a/tests/test_igraph_builder.py
+++ b/tests/test_igraph_builder.py
@@ -16,15 +16,15 @@ def write_gfa(tmp_path: Path) -> Path:
 
 def test_directed_flag(tmp_path: Path):
     gfa = write_gfa(tmp_path)
-    G = parse_gfa_igraph(gfa, build_graph=True, build_matrix=False)
+    G = parse_gfa_igraph(gfa, build_graph=True, build_matrix=False, store_tags=True)
     assert G.is_directed()
-    G2 = parse_gfa_igraph(gfa, build_graph=True, build_matrix=False, directed=False)
+    G2 = parse_gfa_igraph(gfa, build_graph=True, build_matrix=False, directed=False, store_tags=True)
     assert not G2.is_directed()
 
 
 def test_vertex_edge_attributes(tmp_path: Path):
     gfa = write_gfa(tmp_path)
-    G = parse_gfa_igraph(gfa, build_graph=True, build_matrix=False, weight_tag="RC")
+    G = parse_gfa_igraph(gfa, build_graph=True, build_matrix=False, weight_tag="RC", store_tags=True)
     assert G.vcount() == 2
     assert G.ecount() == 1
     v = G.vs.find(name="s1")

--- a/tests/test_store_tags.py
+++ b/tests/test_store_tags.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from gfa2network import parse_gfa
+
+SAMPLE_GFA = b"""S\ts1\t4\tRC:i:5\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\tRC:i:3\n"""
+
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "test.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_store_tags_on(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(gfa, build_graph=True, build_matrix=False, store_tags=True)
+    assert G.nodes["s1"]["tags"] == {"RC": 5}
+    assert G.nodes["s1"]["length"] == 4
+    assert G.edges[("s1", "s2")]["tags"] == {"RC": 3}
+
+
+def test_store_tags_off(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(gfa, build_graph=True, build_matrix=False, store_tags=False)
+    assert "tags" not in G.nodes["s1"]
+    assert "length" not in G.nodes["s1"]
+    assert "tags" not in G.edges[("s1", "s2")]


### PR DESCRIPTION
## Summary
- add `--store-tags` option to CLI and parser
- support storing tags and length on nodes and edges
- warn when stored tags exceed 100 MB
- update igraph builder for optional tags
- document new flag and note about memory use
- add changelog entry
- add tests for tag storage

## Testing
- `PYTHONPATH=. pytest -q`