### PR TITLE
Add warnings for directed bidirected graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.11.0
+- Clarified documentation on graph interpretation and distance semantics.
+- Distance helpers now emit a warning when called on a directed bidirected graph.
+
 ## v0.10.0
 - Saving an adjacency matrix now writes `<outfile>.nodes.tsv` mapping row
   indices to node identifiers.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,17 @@ matrix into CSR/CSC/DOK formats.
 | ``bidirected`` | Append orientation to node IDs |
 | ``raw_bytes_id`` | Use byte strings for node IDs |
 
+## Graph Interpretation
+
+The resulting graphs drop any absolute coordinates from the GFA file and
+encode only connectivity.  When ``--bidirected`` is used, segment
+identifiers are expanded to ``<id>:+`` and ``<id>:-`` so that each node
+represents a specific orientation.  Distances are always computed on the
+undirected topology and ignore coordinates.  If you build a directed
+bidirected graph (``--keep-directed-bidir``) you should convert it to an
+undirected graph via ``G = G.to_undirected()`` before calling the
+distance helpers.
+
 ## Implementation Notes
 
 The parser recognises segment (`S`), link (`L`), edge (`E`), containment (`C`)

--- a/gfa2network/builders.py
+++ b/gfa2network/builders.py
@@ -46,10 +46,47 @@ def parse_gfa(
     raw_bytes_id: bool = False,
     return_node_list: bool = False,
 ):
-    """Stream-parse *path* and return requested artefacts.
+    """Stream-parse *path* and return the requested artefacts.
 
-    Set ``backend="igraph"`` to build an igraph representation instead of a
-    NetworkX graph.
+    Parameters
+    ----------
+    path : str | Path
+        Input GFA file (``-`` for ``stdin``).
+    build_graph : bool
+        Return a NetworkX/igraph graph.
+    build_matrix : bool
+        Return a SciPy sparse adjacency matrix.
+    directed : bool, optional
+        Treat the graph as directed, by default ``True``.
+    weight_tag : str | None, optional
+        Numeric GFA tag to use as edge weight.
+    store_seq : bool, optional
+        Attach sequences from ``S`` records to nodes.
+    store_tags : bool, optional
+        Keep tag dictionaries and segment lengths.
+    strip_orientation : bool, optional
+        Remove ``+/-`` from segment identifiers.
+    verbose : bool, optional
+        Emit progress information.
+    bidirected : bool, optional
+        Duplicate nodes as ``<id>:+`` and ``<id>:-``.
+    keep_directed_bidir : bool, optional
+        Keep directed edges when ``bidirected`` is ``True``.
+    backend : str, optional
+        ``"networkx"`` (default) or ``"igraph"``.
+    dtype : str | object, optional
+        Data type for the adjacency matrix.
+    asymmetric : bool, optional
+        Do not mirror the upper triangle when directed.
+    raw_bytes_id : bool, optional
+        Use raw byte strings for node identifiers.
+    return_node_list : bool, optional
+        Return a node list alongside the matrix.
+
+    Notes
+    -----
+    When the bidirected representation is kept directed, distances should be
+    computed on ``G.to_undirected()`` as orientation is ignored.
     """
     if backend == "igraph":
         return parse_gfa_igraph(

--- a/tests/test_distance_warning.py
+++ b/tests/test_distance_warning.py
@@ -1,0 +1,40 @@
+import pytest
+from pathlib import Path
+import pytest
+from gfa2network import parse_gfa
+from gfa2network.analysis import genome_distance
+
+SAMPLE_GFA = b"""S\ts1\t4\nS\ts2\t4\nL\ts1\t+\ts2\t-\t0M\n"""
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "warn.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_warning_directed_bidirected(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(
+        gfa,
+        build_graph=True,
+        build_matrix=False,
+        bidirected=True,
+        keep_directed_bidir=True,
+    )
+    with pytest.warns(RuntimeWarning):
+        dist = genome_distance(G, ["s1:+"], ["s2:-"])
+    assert dist == 1
+
+
+def test_no_warning_after_to_undirected(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(
+        gfa,
+        build_graph=True,
+        build_matrix=False,
+        bidirected=True,
+        keep_directed_bidir=True,
+    )
+    G = G.to_undirected()
+    dist = genome_distance(G, ["s1:+"], ["s2:-"])
+    assert dist == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -90,6 +90,7 @@ def test_unknown_record_warning(tmp_path: Path):
     gfa = tmp_path / "bad.gfa"
     gfa.write_text("X\tfoo\nX\tbar\n")
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         list(GFAParser(gfa))
     assert len(w) == 1
 


### PR DESCRIPTION
## Summary
- add explicit graph interpretation section in README
- expand parse_gfa and distance helper docstrings
- emit warnings when computing distances on directed bidirected graphs
- cover new warnings with tests
- update changelog

## Testing
- `python -m pytest -Werror -q`
