### PR TITLE
Implement performance warnings and configurable limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.11.0
 - Clarified documentation on graph interpretation and distance semantics.
 - Distance helpers now emit a warning when called on a directed bidirected graph.
+- Finishing-touches: performance warnings, configurable safety limits, CLI polish.
 
 ## v0.10.0
 - Saving an adjacency matrix now writes `<outfile>.nodes.tsv` mapping row

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See `gfa2network -h` for all command line options.
 | Option             | Purpose |
 | ------------------ | ------- |
 | `convert`          | Convert a GFA into graph and/or matrix |
-| `stats`            | Print basic statistics |
+| `stats` (`stat`)   | Print basic statistics |
 | `export`           | Stream edges in various formats |
 | `distance`         | Compute distances between sequences or paths |
 | `distance-matrix`  | Compute pairwise path distances |
@@ -165,12 +165,15 @@ See `gfa2network -h` for all command line options.
 | `--raw-bytes-id`   | Use legacy byte strings for node IDs |
 | `--keep-directed-bidir` | Keep directed bidirected edges |
 | `--verbose`        | Emit progress information |
+| `--max-dense-gb N` | Abort dense matrix saves over N GB |
+| `--max-tag-mb N`   | Warn when stored tags exceed N MB |
+| `--version`        | Print package version |
 
 `--store-seq` may drastically increase memory usage. The parser will warn when the
 stored sequences exceed half of the available RAM. The flag is ignored when only
 `--matrix` is requested. The `--store-tags` option adds tag dictionaries and
-segment lengths to the graph. A `RuntimeWarning` is emitted if more than
-100&nbsp;MB are used for stored tags.
+segment lengths to the graph. A `RuntimeWarning` is emitted when the stored tags
+exceed the threshold from `--max-tag-mb` (default 100&nbsp;MB).
 
 ## Using in Python
 
@@ -215,6 +218,18 @@ computes all pairwise distances between paths and returns a matrix or dataframe.
 The matrix is derived from a cached multi-source Dijkstra search for each path,
 so runtime grows roughly linearly with the number of paths.  ``--method mean``
 averages the node-to-path distances using the same cache.
+
+### Distance matrix
+
+``genome_distance_matrix`` reuses one multi-source Dijkstra search per path. The
+``mean`` method still performs ``|A| × |B|`` shortest path computations. A
+warning is emitted when more than 1000 node pairs are examined:
+
+```python
+>>> genome_distance(G, nodes_a, nodes_b, method="mean")
+RuntimeWarning: Mean distance scales quadratically; this may be very slow on large sets
+```
+Set ``GFANET_DISABLE_WARNINGS=1`` to silence this message.
 
 Pass `store_seq=True` to attach the sequences from `S` records as the
 `sequence` attribute on each node.  You can also set `directed=False` for an

--- a/gfa2network/analysis.py
+++ b/gfa2network/analysis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import networkx as nx
 import warnings
+import os
 
 try:
     import pandas as pd  # type: ignore
@@ -130,6 +131,11 @@ def genome_distance(
             raise nx.NetworkXNoPath("no path between node sets")
         return min(dists)
     elif method == "mean":
+        if len(nodes_a) * len(nodes_b) > 1000 and os.getenv("GFANET_DISABLE_WARNINGS") != "1":
+            warnings.warn(
+                "Mean distance scales quadratically; this may be very slow on large sets",
+                RuntimeWarning,
+            )
         total = 0.0
         count = 0
         for u in nodes_a:

--- a/gfa2network/builders.py
+++ b/gfa2network/builders.py
@@ -45,6 +45,7 @@ def parse_gfa(
     asymmetric: bool = False,
     raw_bytes_id: bool = False,
     return_node_list: bool = False,
+    max_tag_mb: float = 100.0,
 ):
     """Stream-parse *path* and return the requested artefacts.
 
@@ -243,7 +244,7 @@ def parse_gfa(
                 print(
                     f"[warning] stored sequences use {extra_gb:.1f} GB (>50% of available memory)",
                 )
-    if store_tags and build_graph and tags_bytes_total > 100_000_000:
+    if store_tags and build_graph and tags_bytes_total > max_tag_mb * 1_000_000:
         warnings.warn(
             f"stored tag dictionaries use {tags_bytes_total/1e6:.1f} MB",
             RuntimeWarning,

--- a/gfa2network/utils.py
+++ b/gfa2network/utils.py
@@ -63,11 +63,11 @@ def convert_format(A, fmt: str, *, verbose: bool = False):
     return out
 
 
-def save_matrix(A, dest: Path, *, verbose: bool = False):
+def save_matrix(A, dest: Path, *, verbose: bool = False, max_dense_gb: float = 5.0):
     """Write *A* to *dest* with progress bar and dense-size guard."""
     if not _HAS_SCIPY:
         raise RuntimeError("SciPy required for matrix output")
-    MAX_DENSE_BYTES = 5_000_000_000  # 5 GB
+    MAX_DENSE_BYTES = max_dense_gb * 1_000_000_000
     if dest.suffix in {".csv", ".npy"}:
         nnz = A.nnz if sp.issparse(A) else A.size
         if nnz * 8 > MAX_DENSE_BYTES:

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from pathlib import Path
+import pytest
+from gfa2network.cli import main
+
+
+def write_gfa(path: Path, n: int) -> Path:
+    lines = []
+    for i in range(n):
+        lines.append(f"S\t{i}\t*\n")
+    for i in range(n - 1):
+        lines.append(f"L\t{i}\t+\t{i+1}\t+\t0M\n")
+    gfa = path / "big.gfa"
+    gfa.write_text("".join(lines))
+    return gfa
+
+
+def test_dense_matrix_limit(tmp_path: Path):
+    gfa = write_gfa(tmp_path, 400)
+    out = tmp_path / "dense.npy"
+    with pytest.raises(SystemExit):
+        main([
+            "convert",
+            str(gfa),
+            "--matrix",
+            str(out),
+            "--max-dense-gb",
+            "0.001",
+        ])
+

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,18 @@
+import networkx as nx
+import pytest
+from gfa2network.analysis import genome_distance
+
+
+def test_mean_distance_warning():
+    G = nx.Graph()
+    G.add_node("hub")
+    for i in range(50):
+        node = f"a{i}"
+        G.add_edge("hub", node)
+    for i in range(21):
+        node = f"b{i}"
+        G.add_edge("hub", node)
+    set_a = [f"a{i}" for i in range(50)]
+    set_b = [f"b{i}" for i in range(21)]
+    with pytest.warns(RuntimeWarning):
+        genome_distance(G, set_a, set_b, method="mean")


### PR DESCRIPTION
## Summary
- warn when computing mean genome distance on large node sets
- add CLI options `--max-dense-gb` and `--max-tag-mb`
- support `--version` via importlib.metadata and add `stat` alias
- expose dense limit and tag limit in utils and builders
- document new options and behaviour
- test performance warnings and dense limit

## Testing
- `python -m pytest -q`
