### PR TITLE
Add alignment-aware segment splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.12.0
+- Added `--split-on-alignment` option to split segments at alignment
+  boundaries. Emits a warning if the number of sub-nodes exceeds 10× the
+  original segment count.
+
 ## v0.11.0
 - Clarified documentation on graph interpretation and distance semantics.
 - Distance helpers now emit a warning when called on a directed bidirected graph.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ processed on ordinary hardware.
 - Adjacency matrices in several sparse formats
 - Helper utilities to convert or save matrices
 - Bidirected graph representation via `--bidirected`
+- Alignment-aware splitting via `--split-on-alignment`
+  (may increase memory usage; a warning is shown if >10× nodes are created)
 - Compute shortest path distances between sequences or genomes
 - `distance` subcommand to query sequences or paths
 - `distance-matrix` subcommand to compute pairwise path distances
@@ -115,6 +117,9 @@ gfa2network convert input.gfa --matrix adj.npz --matrix-format coo
 
 # Directed graph only with verbose progress output
 gfa2network convert input.gfa --graph --verbose
+
+# Split segments on alignment boundaries
+gfa2network convert input.gfa --graph --split-on-alignment
 
 # Build an igraph representation and save it to disk
 gfa2network convert input.gfa --graph --backend igraph -o graph.pkl

--- a/gfa2network/builders.py
+++ b/gfa2network/builders.py
@@ -46,6 +46,7 @@ def parse_gfa(
     raw_bytes_id: bool = False,
     return_node_list: bool = False,
     max_tag_mb: float = 100.0,
+    split_on_alignment: bool = False,
 ):
     """Stream-parse *path* and return the requested artefacts.
 
@@ -83,6 +84,8 @@ def parse_gfa(
         Use raw byte strings for node identifiers.
     return_node_list : bool, optional
         Return a node list alongside the matrix.
+    split_on_alignment : bool, optional
+        Split segments at alignment boundaries and rewire edges.
 
     Notes
     -----
@@ -103,6 +106,25 @@ def parse_gfa(
             bidirected=bidirected,
             keep_directed_bidir=keep_directed_bidir,
             return_node_list=return_node_list,
+        )
+    if split_on_alignment:
+        return _parse_gfa_split(
+            path,
+            build_graph=build_graph,
+            build_matrix=build_matrix,
+            directed=directed,
+            weight_tag=weight_tag,
+            store_seq=store_seq,
+            store_tags=store_tags,
+            strip_orientation=strip_orientation,
+            verbose=verbose,
+            bidirected=bidirected,
+            keep_directed_bidir=keep_directed_bidir,
+            dtype=dtype,
+            asymmetric=asymmetric,
+            raw_bytes_id=raw_bytes_id,
+            return_node_list=return_node_list,
+            max_tag_mb=max_tag_mb,
         )
     if return_node_list and not build_matrix:
         raise ValueError("return_node_list requires build_matrix=True")
@@ -244,6 +266,228 @@ def parse_gfa(
                 print(
                     f"[warning] stored sequences use {extra_gb:.1f} GB (>50% of available memory)",
                 )
+    if store_tags and build_graph and tags_bytes_total > max_tag_mb * 1_000_000:
+        warnings.warn(
+            f"stored tag dictionaries use {tags_bytes_total/1e6:.1f} MB",
+            RuntimeWarning,
+        )
+
+    out_graph = G
+    out_mat = None
+    node_list = None
+    if build_matrix:
+        n = len(node2idx)
+        dt = np.dtype(dtype)
+        out_mat = sp.coo_matrix((data, (rows, cols)), shape=(n, n), dtype=dt)
+        if not asymmetric and graph_directed:
+            out_mat = out_mat.maximum(out_mat.T)
+        if return_node_list:
+            node_list = [None] * n
+            for node, idx in node2idx.items():
+                val = node if raw_bytes_id else node.decode()
+                node_list[idx] = val
+
+    if build_graph and build_matrix:
+        if return_node_list:
+            return out_graph, out_mat, node_list
+        return out_graph, out_mat
+    if build_graph:
+        return out_graph
+    if build_matrix:
+        if return_node_list:
+            return out_mat, node_list
+        return out_mat
+
+
+def _parse_gfa_split(
+    path: str | Path,
+    *,
+    build_graph: bool,
+    build_matrix: bool,
+    directed: bool,
+    weight_tag: str | None,
+    store_seq: bool,
+    store_tags: bool,
+    strip_orientation: bool,
+    verbose: bool,
+    bidirected: bool,
+    keep_directed_bidir: bool,
+    dtype: str | object,
+    asymmetric: bool,
+    raw_bytes_id: bool,
+    return_node_list: bool,
+    max_tag_mb: float,
+) -> object:
+    import warnings
+    from collections import defaultdict
+
+    parser = GFAParser(path)
+    segments: dict[bytes, Segment] = {}
+    edges: list[EdgeRecord | ContainmentRecord] = []
+    breakpoints: defaultdict[bytes, set[int]] = defaultdict(set)
+
+    for rec in parser:
+        if isinstance(rec, Segment):
+            segments[rec.id] = rec
+            if rec.length is not None:
+                breakpoints[rec.id].update({0, rec.length})
+        elif isinstance(rec, (EdgeRecord, ContainmentRecord)):
+            edges.append(rec)
+            if rec.from_start is not None:
+                breakpoints[rec.from_segment].add(rec.from_start)
+            if rec.from_end is not None:
+                breakpoints[rec.from_segment].add(rec.from_end)
+            if rec.to_start is not None:
+                breakpoints[rec.to_segment].add(rec.to_start)
+            if rec.to_end is not None:
+                breakpoints[rec.to_segment].add(rec.to_end)
+
+    records: list[Segment | Link | EdgeRecord] = []
+    mapping: dict[tuple[bytes, int, int], bytes] = {}
+
+    for seg_id, seg in segments.items():
+        bps = sorted(breakpoints.get(seg_id, {0}))
+        if len(bps) == 1:
+            if seg.length is not None:
+                bps.append(seg.length)
+            else:
+                bps.append(bps[0])
+        intervals: list[tuple[int, int, bytes]] = []
+        for a, b in zip(bps[:-1], bps[1:]):
+            nid = seg_id + b":" + f"{a}-{b}".encode()
+            mapping[(seg_id, a, b)] = nid
+            records.append(Segment(nid, b - a, None, None))
+            intervals.append((a, b, nid))
+        for (a1, b1, id1), (a2, b2, id2) in zip(intervals[:-1], intervals[1:]):
+            records.append(Link(id1, id2, "+", "+", None, None))
+
+    if len(mapping) > 10 * len(segments):
+        warnings.warn("split-on-alignment created >10x more nodes", RuntimeWarning)
+
+    for rec in edges:
+        u = mapping[(rec.from_segment, rec.from_start, rec.from_end)]
+        v = mapping[(rec.to_segment, rec.to_start, rec.to_end)]
+        records.append(
+            EdgeRecord(
+                u,
+                v,
+                rec.orientation_from,
+                rec.orientation_to,
+                rec.from_start,
+                rec.from_end,
+                rec.to_start,
+                rec.to_end,
+                rec.cigar,
+                rec.tags,
+            )
+        )
+
+    # Reuse the main parser logic by iterating over `records`
+    parser_iter = records
+
+    node2idx: dict[bytes, int] = {}
+    rows: list[int] = []
+    cols: list[int] = []
+    data: list[float] = []
+    seq_bytes_total = 0
+    tags_bytes_total = 0
+
+    if bidirected:
+        graph_cls = nx.MultiDiGraph if keep_directed_bidir else nx.MultiGraph
+    else:
+        graph_cls = nx.DiGraph if directed else nx.Graph
+    G = graph_cls() if build_graph else None
+    graph_directed = keep_directed_bidir or (not bidirected and directed)
+
+    node_str: dict[bytes, str] = {}
+
+    def _id(n: bytes) -> bytes | str:
+        if raw_bytes_id:
+            return n
+        s = node_str.get(n)
+        if s is None:
+            s = n.decode("ascii")
+            node_str[n] = s
+        return s
+
+    for lineno, record in enumerate(parser_iter, 1):
+        if isinstance(record, Segment):
+            seg = record.id
+            if build_graph:
+                attrs = {}
+                if store_seq and record.sequence is not None:
+                    attrs["sequence"] = record.sequence
+                    seq_bytes_total += len(record.sequence)
+                if store_tags and record.length is not None:
+                    attrs["length"] = record.length
+                if store_tags and record.tags is not None:
+                    attrs["tags"] = record.tags
+                    tags_bytes_total += len(pickle.dumps(record.tags))
+                G.add_node(_id(seg), **attrs)
+            if build_matrix:
+                if seg not in node2idx:
+                    node2idx[seg] = len(node2idx)
+        elif isinstance(record, (Link, EdgeRecord)):
+            u = record.from_segment
+            v = record.to_segment
+            if strip_orientation:
+                u = u.rstrip(b"+-")
+                v = v.rstrip(b"+-")
+            w: float | None = None
+            if weight_tag and record.tags and weight_tag in record.tags:
+                val = record.tags[weight_tag]
+                if isinstance(val, (int, float)):
+                    w = float(val)
+            if bidirected:
+                u_node = u + b":" + record.orientation_from.encode()
+                v_node = v + b":" + record.orientation_to.encode()
+            else:
+                u_node = u
+                v_node = v
+            if build_matrix:
+
+                def add_mat_edge(a: bytes, b: bytes) -> None:
+                    for n in (a, b):
+                        if n not in node2idx:
+                            node2idx[n] = len(node2idx)
+                    rows.append(node2idx[a])
+                    cols.append(node2idx[b])
+                    data.append(1.0 if w is None else w)
+                    if not graph_directed:
+                        rows.append(node2idx[b])
+                        cols.append(node2idx[a])
+                        data.append(1.0 if w is None else w)
+
+                add_mat_edge(u_node, v_node)
+                if bidirected and not keep_directed_bidir:
+                    rev_from = b"-" if record.orientation_from == "+" else b"+"
+                    rev_to = b"-" if record.orientation_to == "+" else b"+"
+                    add_mat_edge(v + b":" + rev_to, u + b":" + rev_from)
+            if build_graph:
+                attrs = {}
+                if not strip_orientation and not bidirected:
+                    attrs = {
+                        "orientation_from": record.orientation_from,
+                        "orientation_to": record.orientation_to,
+                    }
+                if store_tags and record.tags is not None:
+                    attrs["tags"] = record.tags
+                    tags_bytes_total += len(pickle.dumps(record.tags))
+
+                def add_graph_edge(a: bytes, b: bytes) -> None:
+                    if w is None:
+                        G.add_edge(_id(a), _id(b), **attrs)
+                    else:
+                        G.add_edge(_id(a), _id(b), weight=w, **attrs)
+
+                add_graph_edge(u_node, v_node)
+                if bidirected and not keep_directed_bidir:
+                    rev_from = b"-" if record.orientation_from == "+" else b"+"
+                    rev_to = b"-" if record.orientation_to == "+" else b"+"
+                    add_graph_edge(v + b":" + rev_to, u + b":" + rev_from)
+
+    if build_graph and verbose:
+        print("\r[parse_gfa_split] done")
     if store_tags and build_graph and tags_bytes_total > max_tag_mb * 1_000_000:
         warnings.warn(
             f"stored tag dictionaries use {tags_bytes_total/1e6:.1f} MB",

--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -109,6 +109,11 @@ def main(argv: list[str] | None = None) -> None:
     p_conv.add_argument("--store-seq", action="store_true")
     p_conv.add_argument("--store-tags", action="store_true")
     p_conv.add_argument(
+        "--split-on-alignment",
+        action="store_true",
+        help="Split segments at alignment boundaries",
+    )
+    p_conv.add_argument(
         "--strip-orientation",
         action="store_true",
         help="Strip +/- from IDs (v0.1 behaviour)",
@@ -202,6 +207,7 @@ def main(argv: list[str] | None = None) -> None:
             raw_bytes_id=args.raw_bytes_id,
             return_node_list=build_mat and not args.no_node_map,
             max_tag_mb=args.max_tag_mb,
+            split_on_alignment=args.split_on_alignment,
         )
         if build_g and build_mat:
             if build_mat and not args.no_node_map:

--- a/tests/test_split_alignment.py
+++ b/tests/test_split_alignment.py
@@ -1,0 +1,25 @@
+import networkx as nx
+from pathlib import Path
+from gfa2network import parse_gfa
+
+SAMPLE_GFA = b"""S\ts1\t6\nS\ts2\t10\nE\t*\ts1+\t0\t6\ts2+\t0\t6\t6M\n"""
+
+def write_gfa(tmp_path: Path) -> Path:
+    gfa = tmp_path / "a.gfa"
+    gfa.write_bytes(SAMPLE_GFA)
+    return gfa
+
+
+def test_no_split(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(gfa, build_graph=True, build_matrix=False)
+    assert G.number_of_nodes() == 2
+    assert G.number_of_edges() == 1
+
+
+def test_split_on_alignment(tmp_path: Path):
+    gfa = write_gfa(tmp_path)
+    G = parse_gfa(gfa, build_graph=True, build_matrix=False, split_on_alignment=True)
+    assert G.number_of_nodes() == 3
+    assert G.number_of_edges() == 2
+    assert nx.shortest_path_length(G, "s1:0-6", "s2:6-10") == 2


### PR DESCRIPTION
## Summary
- extend parser records with alignment coordinates
- support optional `--split-on-alignment` mode in parser and CLI
- split segments into interval nodes and rewire edges
- document the new option and update changelog
- add unit test for alignment splitting

## Testing
- `PYTHONPATH=. pytest -q`