### PR TITLE
Handle split-mode links and add citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ This project targets Python 3.8 or later and depends on the following packages:
 - `pytest` (optional) for running the unit tests
 - `python-igraph` (optional) for the igraph backend
 
+## Comparison to Other Tools
+
+`gfapy` focuses on full read/write support for all GFA fields while
+`vg` and `ODGI` provide highly optimised graph implementations with many
+algorithms built in.  **GFA2Network** is a lightweight parser whose niche is
+streaming conversion of GFA files into NetworkX graphs or sparse matrices with
+very small memory overhead.  Use it when you only need the basic connectivity in
+a familiar Python representation without loading an entire toolkit.
+
 ## Quick Start
 
 The examples below illustrate typical use cases.  Replace `input.gfa` with your

--- a/tests/test_split_alignment.py
+++ b/tests/test_split_alignment.py
@@ -4,6 +4,7 @@ from gfa2network import parse_gfa
 
 SAMPLE_GFA = b"""S\ts1\t6\nS\ts2\t10\nE\t*\ts1+\t0\t6\ts2+\t0\t6\t6M\n"""
 ORIENT_GFA = b"""S\ts1\t6\nS\ts2\t10\nE\t*\ts1\t+\ts2\t+\n"""
+LINK_GFA = b"""S\ts1\t6\nS\ts2\t10\nL\ts1\t+\ts2\t-\t0M\nE\t*\ts1+\t0\t3\ts2+\t0\t3\t3M\n"""
 
 def write_gfa(tmp_path: Path) -> Path:
     gfa = tmp_path / "a.gfa"
@@ -32,3 +33,15 @@ def test_split_orientation_only_edges(tmp_path: Path):
     G = parse_gfa(gfa, build_graph=True, build_matrix=False, split_on_alignment=True)
     assert G.number_of_nodes() == 2
     assert G.number_of_edges() == 1
+
+
+def test_split_with_link_records(tmp_path: Path):
+    gfa = tmp_path / "c.gfa"
+    gfa.write_bytes(LINK_GFA)
+    G = parse_gfa(gfa, build_graph=True, build_matrix=False, split_on_alignment=True)
+    assert G.number_of_nodes() == 4
+    # verify that the link edge was preserved after splitting
+    assert ("s1:0-3", "s2:0-3") in G.edges
+    attrs = G.edges[("s1:0-3", "s2:0-3")]
+    assert attrs["orientation_from"] == "+"
+    assert attrs["orientation_to"] == "-"


### PR DESCRIPTION
## Summary
- support GFA link records when splitting on alignments
- add regression test for link handling
- document how GFA2Network compares to tools like gfapy, ODGI and vg
- remove temporary citation metadata until publication

## Testing
- `python -m pytest -q`