### PR TITLE
Add igraph progress_step and test full large graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+anellograph_k21.complete.norm.gfa.gz

--- a/tests/test_large_graph.py
+++ b/tests/test_large_graph.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from gfa2network import parse_gfa
+
+LARGE_GRAPH_PATH = Path(os.environ.get("LARGE_GRAPH", ""))
+
+
+@pytest.mark.skipif(not LARGE_GRAPH_PATH.exists(), reason="large graph not available")
+def test_parse_large_graph_verbose(capsys):
+    parse_gfa(LARGE_GRAPH_PATH, build_graph=False, build_matrix=False, verbose=True)
+    captured = capsys.readouterr()
+    assert "[parse_gfa] done" in captured.out
+    assert "lines]" in captured.err
+
+
+@pytest.mark.skipif(not LARGE_GRAPH_PATH.exists(), reason="large graph not available")
+def test_igraph_backend_verbose(capsys):
+    parse_gfa(
+        LARGE_GRAPH_PATH,
+        build_graph=False,
+        build_matrix=False,
+        backend="igraph",
+        verbose=True,
+    )
+    captured = capsys.readouterr()
+    assert "[parse_gfa_igraph] done" in captured.out
+    assert "lines]" in captured.err


### PR DESCRIPTION
## Summary
- improve igraph backend progress handling and skip building graph when unused
- ensure progress prints to stderr with configurable `progress_step`
- parse the full large graph in tests without subsetting

## Testing
- `isort gfa2network/igraph_builder.py tests/test_large_graph.py`
- `black gfa2network/igraph_builder.py tests/test_large_graph.py`
- `PYTHONPATH=. pytest -k "not large_graph" -q`
- `PYTHONPATH=. pytest tests/test_large_graph.py::test_parse_large_graph_verbose -q`
- `PYTHONPATH=. pytest tests/test_large_graph.py::test_igraph_backend_verbose -q`
- `PYTHONPATH=. pytest -q`