### PR TITLE
Add verbose argument to save_matrix

### DIFF
--- a/gfa2network/cli.py
+++ b/gfa2network/cli.py
@@ -356,6 +356,7 @@ def main(argv: list[str] | None = None) -> None:
             save_matrix(
                 M,
                 Path(args.output),
+                verbose=args.verbose,
                 max_dense_gb=args.max_dense_gb,
             )
         except MemoryError as exc:


### PR DESCRIPTION
## Summary
- pass CLI verbose flag to `save_matrix` when computing distance matrices

## Testing
- `scripts/lint_check.sh` *(fails: 14 files would be reformatted)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840bbcf3498832998ce45749532835f